### PR TITLE
Allow Github actions to publish javadocs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,11 +3,11 @@ name: Build
 on:
   push:
     branches: [ "master" ]
-  pull_request_target:
+  pull_request:
     branches: [ "master" ]
 
 permissions:
-  contents: read
+  contents: write
   checks: write
 
 jobs:


### PR DESCRIPTION
This commit allows GitHub actions to publish javadocs. It also changes the target to pull_request.