### PR TITLE
cd: Automated releases

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,8 +1,10 @@
 name: Build and Deploy
 
 on:
+  workflow_dispatch:
   push:
-    branches: [ "master" ]
+    tags:
+      - 'v*'
 
 permissions:
   contents: write
@@ -52,7 +54,28 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     needs: build
+    env:
+      ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEYID }}
+      ORG_GRADLE_PROJECT_signingKey: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEY }}
+      ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGPASSWORD }}
+      ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.ORG_GRADLE_PROJECT_SONATYPEUSERNAME }}
+      ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.ORG_GRADLE_PROJECT_SONATYPEPASSWORD }}
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Build
+        uses: gradle/gradle-build-action@v2
+        with:
+          gradle-version: 8.5
+          arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+
       - name: Deploy javadoc to Github Pages
         uses: dev-vince/actions-publish-javadoc@v1.0.1
         with:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -70,7 +70,7 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
 
-      - name: Build
+      - name: Publish package
         uses: gradle/gradle-build-action@v2
         with:
           gradle-version: 8.5

--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,7 @@ plugins {
 
 	id 'com.google.protobuf' version '0.9.4'
 	id "net.ltgt.errorprone" version '3.1.0'
+	id 'io.github.gradle-nexus.publish-plugin' version "1.3.0"
 }
 
 group = 'io.qdrant'
@@ -201,6 +202,7 @@ publishing {
 		mavenJava(MavenPublication) {
 			from components.java
 			pom {
+				name = "Qdrant Java Client"
 				description = "${project.description}"
 				url = "https://github.com/${organization}/${repository}"
 				licenses {
@@ -228,4 +230,20 @@ publishing {
 	repositories {
 		mavenLocal()
 	}
+}
+
+nexusPublishing {
+    repositories {
+        sonatype {
+            nexusUrl = uri("https://s01.oss.sonatype.org/service/local/")
+            snapshotRepositoryUrl = uri("https://s01.oss.sonatype.org/content/repositories/snapshots/")
+        }
+    }
+}
+signing {
+	def signingKeyId = findProperty("signingKeyId")
+    def signingKey = findProperty("signingKey")
+    def signingPassword = findProperty("signingPassword")
+    useInMemoryPgpKeys(signingKeyId, signingKey, signingPassword)
+    sign publishing.publications.mavenJava
 }


### PR DESCRIPTION

This PR intends to add a release workflow that publishes the `io.qdrant.client` package to https://central.sonatype.com/.
The required repository secrets have been configured.
A demo run of this workflow can be found [here](https://github.com/Anush008/java-client-ci/actions/runs/7279585005).