### PR TITLE
feat: Batch update points

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ To install the library, add the following lines to your build config file.
 </dependency>
 ```
 
-#### Scala SBT
+#### SBT
 
 ```sbt
 libraryDependencies += "io.qdrant" % "client" % "1.7.1"

--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ implementation 'io.qdrant:client:1.7.1'
 
 ## 📖 Documentation
 
-- [`QdrantClient` Reference](https://qdrant.github.io/java-client/io/qdrant/client/QdrantClient.html#constructor-detail)
+- [JavaDoc Reference](https://qdrant.github.io/java-client/io/qdrant/client/QdrantClient.html#constructor-detail)
+- Usage examples are available throughout the [Qdrant documentation](https://qdrant.tech/documentation/quick-start/)
 
 ## 🔌 Getting started
 
@@ -127,20 +128,25 @@ import static io.qdrant.client.PointIdFactory.id;
 import static io.qdrant.client.ValueFactory.value;
 import static io.qdrant.client.VectorsFactory.vectors;
 
-Random random = new Random();
-List<PointStruct> points = IntStream.range(1, 101)
-  .mapToObj(i -> PointStruct.newBuilder()
-    .setId(id(i))
-    .setVectors(vectors(IntStream.range(1, 101)
-        .mapToObj(v -> random.nextFloat())
-        .collect(Collectors.toList())))
-    .putAllPayload(ImmutableMap.of(
-      "color", value("red"),
-      "rand_number", value(i % 10))
-    )
-    .build()
-  )
-  .collect(Collectors.toList());
+List<PointStruct> points =
+    List.of(
+        PointStruct.newBuilder()
+            .setId(id(1))
+            .setVectors(vectors(0.32f, 0.52f, 0.21f, 0.52f))
+            .putAllPayload(
+                Map.of(
+                    "color", value("red"),
+                    "rand_number", value(32)))
+            .build(),
+        PointStruct.newBuilder()
+            .setId(id(2))
+            .setVectors(vectors(0.42f, 0.52f, 0.67f, 0.632f))
+            .putAllPayload(
+                Map.of(
+                    "color", value("black"),
+                    "rand_number", value(53),
+                    "extra_field", value(true)))
+            .build());
 
 UpdateResult updateResult = client.upsertAsync("my_collection", points).get();
 ```
@@ -148,16 +154,15 @@ UpdateResult updateResult = client.upsertAsync("my_collection", points).get();
 Search for similar vectors
 
 ```java
-List<Float> queryVector = IntStream.range(1, 101)
-  .mapToObj(v -> random.nextFloat())
-  .collect(Collectors.toList());
-
-List<ScoredPoint> points = client.searchAsync(SearchPoints.newBuilder()
-  .setCollectionName("my_collection")
-  .addAllVector(queryVector)
-  .setLimit(5)
-  .build()
-).get();
+List<ScoredPoint> anush =
+    client
+        .searchAsync(
+            SearchPoints.newBuilder()
+                .setCollectionName("my_collection")
+                .addAllVector(List.of(0.6235f, 0.123f, 0.532f, 0.123f))
+                .setLimit(5)
+                .build())
+        .get();
 ```
 
 Search for similar vectors with filtering condition
@@ -168,7 +173,7 @@ import static io.qdrant.client.ConditionFactory.range;
 
 List<ScoredPoint> points = client.searchAsync(SearchPoints.newBuilder()
   .setCollectionName("my_collection")
-  .addAllVector(queryVector)
+  .addAllVector(List.of(0.6235f, 0.123f, 0.532f, 0.123f))
   .setFilter(Filter.newBuilder()
     .addMust(range("rand_number", Range.newBuilder().setGte(3).build()))
     .build())

--- a/README.md
+++ b/README.md
@@ -34,20 +34,20 @@ To install the library, add the following lines to your build config file.
 <dependency>
   <groupId>io.qdrant</groupId>
   <artifactId>client</artifactId>
-  <version>1.7.0</version>
+  <version>1.7.1</version>
 </dependency>
 ```
 
 #### Scala SBT
 
 ```sbt
-libraryDependencies += "io.qdrant" % "client" % "1.7.0"
+libraryDependencies += "io.qdrant" % "client" % "1.7.1"
 ```
 
 #### Gradle
 
 ```gradle
-implementation 'io.qdrant:client:1.7.0'
+implementation 'io.qdrant:client:1.7.1'
 ```
 
 ## 📖 Documentation
@@ -125,13 +125,13 @@ Insert vectors into a collection
 // import static convenience methods
 import static io.qdrant.client.PointIdFactory.id;
 import static io.qdrant.client.ValueFactory.value;
-import static io.qdrant.client.VectorsFactory.vector;
+import static io.qdrant.client.VectorsFactory.vectors;
 
 Random random = new Random();
 List<PointStruct> points = IntStream.range(1, 101)
   .mapToObj(i -> PointStruct.newBuilder()
     .setId(id(i))
-    .setVectors(vector(IntStream.range(1, 101)
+    .setVectors(vectors(IntStream.range(1, 101)
         .mapToObj(v -> random.nextFloat())
         .collect(Collectors.toList())))
     .putAllPayload(ImmutableMap.of(

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ implementation 'io.qdrant:client:1.7.1'
 
 ## 📖 Documentation
 
-- [JavaDoc Reference](https://qdrant.github.io/java-client/io/qdrant/client/QdrantClient.html#constructor-detail)
+- [JavaDoc Reference](https://qdrant.github.io/java-client/)
 - Usage examples are available throughout the [Qdrant documentation](https://qdrant.tech/documentation/quick-start/)
 
 ## 🔌 Getting started

--- a/build.gradle
+++ b/build.gradle
@@ -19,8 +19,8 @@ plugins {
 	id 'maven-publish'
 
 	id 'com.google.protobuf' version '0.9.4'
-	id "net.ltgt.errorprone" version '3.1.0'
-	id 'io.github.gradle-nexus.publish-plugin' version "1.3.0"
+	id 'net.ltgt.errorprone' version '3.1.0'
+	id 'io.github.gradle-nexus.publish-plugin' version '1.3.0'
 }
 
 group = 'io.qdrant'

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,4 +5,4 @@ qdrantProtosVersion=v1.7.0
 qdrantVersion=v1.7.0
 
 # The version of the client to generate
-packageVersion=1.7.0
+packageVersion=1.7.1

--- a/src/main/java/io/qdrant/client/QdrantClient.java
+++ b/src/main/java/io/qdrant/client/QdrantClient.java
@@ -2257,13 +2257,16 @@ public class QdrantClient implements AutoCloseable {
 	 * 
 	 * @return a new instance of {@link ListenableFuture}
 	 */
-	public ListenableFuture<UpdateBatchResponse> batchUpdateAsync(UpdateBatchPoints request, @Nullable Duration timeout) {
+	public ListenableFuture<List<UpdateResult>> batchUpdateAsync(UpdateBatchPoints request, @Nullable Duration timeout) {
 		String collectionName = request.getCollectionName();
 		Preconditions.checkArgument(!collectionName.isEmpty(), "Collection name must not be empty");
 		logger.debug("Batch update points on '{}'", collectionName);
 		ListenableFuture<UpdateBatchResponse> future = getPoints(timeout).updateBatch(request);
 		addLogFailureCallback(future, "Batch update points");
-		return future;
+		return Futures.transform(
+			future,
+			UpdateBatchResponse::getResultList,
+			MoreExecutors.directExecutor());
 	}
 
 	/**

--- a/src/main/java/io/qdrant/client/QdrantClient.java
+++ b/src/main/java/io/qdrant/client/QdrantClient.java
@@ -1554,7 +1554,7 @@ public class QdrantClient implements AutoCloseable {
 	}
 
 	/**
-	 * Overwrites the payload for the filterd points.
+	 * Overwrites the payload for the filtered points.
 	 *
 	 * @param collectionName The name of the collection.
 	 * @param payload New payload values

--- a/src/main/java/io/qdrant/client/QdrantClient.java
+++ b/src/main/java/io/qdrant/client/QdrantClient.java
@@ -2215,7 +2215,7 @@ public class QdrantClient implements AutoCloseable {
 	 * 
 	 * @return a new instance of {@link ListenableFuture}
 	 */
-	public ListenableFuture<UpdateBatchResponse> batchUpdateAsync(String collectionName, List<PointsUpdateOperation> operations) {
+	public ListenableFuture<List<UpdateResult>> batchUpdateAsync(String collectionName, List<PointsUpdateOperation> operations) {
 		return batchUpdateAsync(collectionName, operations, null, null, null);
 	}
 
@@ -2230,7 +2230,7 @@ public class QdrantClient implements AutoCloseable {
 	 * 
 	 * @return a new instance of {@link ListenableFuture}
 	 */
-	public ListenableFuture<UpdateBatchResponse> batchUpdateAsync(
+	public ListenableFuture<List<UpdateResult>> batchUpdateAsync(
 		String collectionName,
 		List<PointsUpdateOperation> operations, 
 		@Nullable Boolean wait, 

--- a/src/main/java/io/qdrant/client/QdrantClient.java
+++ b/src/main/java/io/qdrant/client/QdrantClient.java
@@ -1554,7 +1554,7 @@ public class QdrantClient implements AutoCloseable {
 	}
 
 	/**
-	 * Overwrites the payload for the given ids.
+	 * Overwrites the payload for the filterd points.
 	 *
 	 * @param collectionName The name of the collection.
 	 * @param payload New payload values
@@ -1699,7 +1699,7 @@ public class QdrantClient implements AutoCloseable {
 	}
 
 	/**
-	 * Delete specified key payload for the given ids.
+	 * Delete specified key payload for the filtered points.
 	 *
 	 * @param collectionName The name of the collection.
 	 * @param keys List of keys to delete.
@@ -1835,7 +1835,7 @@ public class QdrantClient implements AutoCloseable {
 	}
 
 	/**
-	 * Removes all payload for the given ids.
+	 * Removes all payload for the filtered points.
 	 *
 	 * @param collectionName The name of the collection.
 	 * @param filter A filter selecting the points for which to remove the payload.

--- a/src/main/java/io/qdrant/client/VectorsFactory.java
+++ b/src/main/java/io/qdrant/client/VectorsFactory.java
@@ -25,7 +25,7 @@ public final class VectorsFactory {
 	public static Vectors namedVectors(Map<String, Vector> values) {
 		return Vectors.newBuilder()
 			.setVectors(NamedVectors.newBuilder()
-				.putAllVectors(Maps.transformValues(values, v -> v))
+				.putAllVectors(values)
 			)
 			.build();
 	}

--- a/src/main/java/io/qdrant/client/VectorsFactory.java
+++ b/src/main/java/io/qdrant/client/VectorsFactory.java
@@ -7,6 +7,7 @@ import java.util.Map;
 
 import static io.qdrant.client.VectorFactory.vector;
 import static io.qdrant.client.grpc.Points.NamedVectors;
+import io.qdrant.client.grpc.Points.Vector;
 import static io.qdrant.client.grpc.Points.Vectors;
 
 /**
@@ -18,13 +19,13 @@ public final class VectorsFactory {
 
 	/**
 	 * Creates named vectors
-	 * @param values A map of vector names to values
+	 * @param values A map of vector names to {@link Vector}
 	 * @return a new instance of {@link Vectors}
 	 */
-	public static Vectors namedVectors(Map<String, List<Float>> values) {
+	public static Vectors namedVectors(Map<String, Vector> values) {
 		return Vectors.newBuilder()
 			.setVectors(NamedVectors.newBuilder()
-				.putAllVectors(Maps.transformValues(values, v -> vector(v)))
+				.putAllVectors(Maps.transformValues(values, v -> v))
 			)
 			.build();
 	}

--- a/src/test/java/io/qdrant/client/PointsTest.java
+++ b/src/test/java/io/qdrant/client/PointsTest.java
@@ -565,9 +565,9 @@ class PointsTest {
 										.setVectors(vectors(0.6f, 0.7f))))
 						.build());
 
-		UpdateBatchResponse response = client.batchUpdateAsync(testName, operations).get();
+		List<UpdateResult> response = client.batchUpdateAsync(testName, operations).get();
 
-		response.getResultList().forEach(result -> assertEquals(UpdateStatus.Completed, result.getStatus()));
+		response.forEach(result -> assertEquals(UpdateStatus.Completed, result.getStatus()));
 	}
 
 	private void createAndSeedCollection(String collectionName) throws ExecutionException, InterruptedException {


### PR DESCRIPTION
This PR

- Adds support for [batch point update operation](https://qdrant.tech/documentation/concepts/points/#batch-update).
- Updates the `VectorsFactory.namedVector()` to accept `Map<String, Vector>` to support creating sparse vectors. Can't add an overload for generic types.