### PR TITLE
Expose gRPC client on high level client

### DIFF
--- a/src/main/java/io/qdrant/client/QdrantClient.java
+++ b/src/main/java/io/qdrant/client/QdrantClient.java
@@ -138,6 +138,19 @@ public class QdrantClient implements AutoCloseable {
 	}
 
 	/**
+	 * Gets the low-level gRPC client. This is exposed to
+	 * <ul>
+	 *     <li>Allow access to the underlying gRPC channel</li>
+	 *     <li>Allow access to the gRPC client to make requests using the low-level gRPC client in cases
+	 *     where functionality may not yet be exposed by the higher level client.</li>
+	 * </ul>
+	 * @return The low-level gRPC client
+	 */
+	public QdrantGrpcClient grpcClient() {
+		return grpcClient;
+	}
+
+	/**
 	 * Gets detailed information about the qdrant cluster.
 	 *
 	 * @return a new instance of {@link ListenableFuture}

--- a/src/main/java/io/qdrant/client/QdrantGrpcClient.java
+++ b/src/main/java/io/qdrant/client/QdrantGrpcClient.java
@@ -96,6 +96,14 @@ public class QdrantGrpcClient implements AutoCloseable {
 	}
 
 	/**
+	 * Gets the channel
+	 * @return the channel
+	 */
+	public ManagedChannel channel() {
+		return channel;
+	}
+
+	/**
 	 * Gets the client for qdrant services
 	 * @return a new instance of {@link QdrantFutureStub}
 	 */

--- a/src/test/java/io/qdrant/client/QdrantClientTest.java
+++ b/src/test/java/io/qdrant/client/QdrantClientTest.java
@@ -1,0 +1,40 @@
+package io.qdrant.client;
+
+import io.grpc.Grpc;
+import io.grpc.InsecureChannelCredentials;
+import io.grpc.ManagedChannel;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.qdrant.QdrantContainer;
+
+@Testcontainers
+class QdrantClientTest {
+
+	@Container
+	private static final QdrantContainer QDRANT_CONTAINER = new QdrantContainer(DockerImage.QDRANT_IMAGE);
+	private QdrantClient client;
+
+	@BeforeEach
+	public void setup() {
+		ManagedChannel channel = Grpc.newChannelBuilder(
+				QDRANT_CONTAINER.getGrpcHostAddress(),
+				InsecureChannelCredentials.create())
+			.build();
+		QdrantGrpcClient grpcClient = QdrantGrpcClient.newBuilder(channel, true).build();
+		client = new QdrantClient(grpcClient);
+	}
+
+	@AfterEach
+	public void teardown() {
+		client.close();
+	}
+
+	@Test
+	void canAccessChannelOnGrpcClient() {
+		Assertions.assertTrue(client.grpcClient().channel().authority().startsWith("localhost"));
+	}
+}


### PR DESCRIPTION
This commit exposes the low-level gRPC client on the high level client, for two purposes:

- Allow access to the underlying gRPC channel. This may be useful for capturing properties about the channel e.g. the channel authority, for metrics.
- Allow access to the gRPC client to make requests using the low-level gRPC client in cases where functionality may not yet be exposed by the higher level client.