### PR TITLE
Russcam noop slf4j tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -80,6 +80,7 @@ jar {
 def grpcVersion = '1.59.0'
 def protobufVersion = '3.24.0'
 def protocVersion = protobufVersion
+def slf4jVersion = '2.0.7'
 def testcontainersVersion = '1.19.6'
 def jUnitVersion = '5.8.1'
 
@@ -90,7 +91,7 @@ dependencies {
 	implementation "io.grpc:grpc-services:${grpcVersion}"
 	implementation "io.grpc:grpc-stub:${grpcVersion}"
 	implementation "com.google.guava:guava:30.1-jre"
-	implementation "org.slf4j:slf4j-api:2.0.7"
+	implementation "org.slf4j:slf4j-api:${slf4jVersion}"
 
 	compileOnly "org.apache.tomcat:annotations-api:6.0.53"
 	compileOnly "com.google.code.findbugs:jsr305:3.0.2"
@@ -102,6 +103,7 @@ dependencies {
 	testImplementation "io.grpc:grpc-testing:${grpcVersion}"
 	testImplementation "org.junit.jupiter:junit-jupiter-api:${jUnitVersion}"
 	testImplementation "org.mockito:mockito-core:3.4.0"
+	testImplementation "org.slf4j:slf4j-nop:${slf4jVersion}"
 	testImplementation "org.testcontainers:qdrant:${testcontainersVersion}"
 	testImplementation "org.testcontainers:junit-jupiter:${testcontainersVersion}"
 

--- a/src/main/java/io/qdrant/client/QdrantClient.java
+++ b/src/main/java/io/qdrant/client/QdrantClient.java
@@ -2594,7 +2594,7 @@ public class QdrantClient implements AutoCloseable {
 		addLogFailureCallback(future, "Discover");
 		return Futures.transform(
 			future,
-			response -> response.getResultList(),
+			DiscoverResponse::getResultList,
 			MoreExecutors.directExecutor());
 	}
 
@@ -2644,9 +2644,9 @@ public class QdrantClient implements AutoCloseable {
 		ListenableFuture<DiscoverBatchResponse> future = getPoints(timeout).discoverBatch(requestBuilder.build());
 		addLogFailureCallback(future, "Discover batch");
 		return Futures.transform(
-				future,
-				response -> response.getResultList(),
-				MoreExecutors.directExecutor());
+			future,
+			DiscoverBatchResponse::getResultList,
+			MoreExecutors.directExecutor());
 	}
 
 	/**


### PR DESCRIPTION
This PR adds nop slf4j test dependency, to suppress noProviders warning.

It also fixes a couple of small suggestions.