### PR TITLE
feat: use java 8 api instead of exposing guava types

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -103,6 +103,7 @@ dependencies {
 	testImplementation "io.grpc:grpc-testing:${grpcVersion}"
 	testImplementation "org.junit.jupiter:junit-jupiter-api:${jUnitVersion}"
 	testImplementation "org.mockito:mockito-core:3.4.0"
+	testImplementation "org.assertj:assertj-core:3.25.3"
 	testImplementation "org.slf4j:slf4j-nop:${slf4jVersion}"
 	testImplementation "org.testcontainers:qdrant:${testcontainersVersion}"
 	testImplementation "org.testcontainers:junit-jupiter:${testcontainersVersion}"

--- a/src/main/java/io/qdrant/client/futureconverter/FutureConverter.java
+++ b/src/main/java/io/qdrant/client/futureconverter/FutureConverter.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2014-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.qdrant.client.futureconverter;
+
+
+import com.google.common.util.concurrent.ListenableFuture;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Converts between {@link java.util.concurrent.CompletableFuture} and Guava {@link com.google.common.util.concurrent.ListenableFuture}.
+ */
+public class FutureConverter {
+
+    /**
+     * Converts {@link java.util.concurrent.CompletableFuture} to {@link com.google.common.util.concurrent.ListenableFuture}.
+     */
+    public static <T> ListenableFuture<T> toListenableFuture(CompletableFuture<T> completableFuture) {
+        return GuavaFutureUtils.createListenableFuture(Java8FutureUtils.createValueSourceFuture(completableFuture));
+    }
+
+    /**
+     * Converts  {@link com.google.common.util.concurrent.ListenableFuture} to {@link java.util.concurrent.CompletableFuture}.
+     */
+    public static <T> CompletableFuture<T> toCompletableFuture(ListenableFuture<T> listenableFuture) {
+        return Java8FutureUtils.createCompletableFuture(GuavaFutureUtils.createValueSourceFuture(listenableFuture));
+    }
+}

--- a/src/main/java/io/qdrant/client/futureconverter/FutureWrapper.java
+++ b/src/main/java/io/qdrant/client/futureconverter/FutureWrapper.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2014-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.qdrant.client.futureconverter;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * Wraps future and delegates to wrapped.
+ */
+public class FutureWrapper<T> implements Future<T> {
+    private final Future<T> wrappedFuture;
+
+    protected FutureWrapper(Future<T> wrappedFuture) {
+        if (wrappedFuture == null) {
+            throw new NullPointerException("Wrapped future can not be null");
+        }
+        this.wrappedFuture = wrappedFuture;
+    }
+
+    @Override
+    public boolean cancel(boolean mayInterruptIfRunning) {
+        return wrappedFuture.cancel(mayInterruptIfRunning);
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return wrappedFuture.isCancelled();
+    }
+
+    @Override
+    public boolean isDone() {
+        return wrappedFuture.isDone();
+    }
+
+    @Override
+    public T get() throws InterruptedException, ExecutionException {
+        return wrappedFuture.get();
+    }
+
+    @Override
+    public T get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+        return wrappedFuture.get(timeout, unit);
+    }
+
+    protected Future<T> getWrappedFuture() {
+        return wrappedFuture;
+    }
+}

--- a/src/main/java/io/qdrant/client/futureconverter/GuavaFutureUtils.java
+++ b/src/main/java/io/qdrant/client/futureconverter/GuavaFutureUtils.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright © 2014-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.qdrant.client.futureconverter;
+
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.MoreExecutors;
+
+import java.util.concurrent.Executor;
+import java.util.function.Consumer;
+
+
+public class GuavaFutureUtils {
+    // *************************************** Converting to ListenableFuture ******************************************
+
+    /**
+     * Creates listenable future from ValueSourceFuture. We have to send all Future API calls to ValueSourceFuture.
+     */
+    public static <T> ListenableFuture<T> createListenableFuture(ValueSourceFuture<T> valueSourceFuture) {
+        if (valueSourceFuture instanceof ListenableFutureBackedValueSourceFuture) {
+            return ((ListenableFutureBackedValueSourceFuture<T>) valueSourceFuture).getWrappedFuture();
+        } else {
+            return new ValueSourceFutureBackedListenableFuture<>(valueSourceFuture);
+        }
+    }
+
+    public static <T> ListenableFuture<T> createListenableFuture(ValueSource<T> valueSource) {
+        if (valueSource instanceof ListenableFutureBackedValueSourceFuture) {
+            return ((ListenableFutureBackedValueSourceFuture<T>) valueSource).getWrappedFuture();
+        } else {
+            return new ValueSourceBackedListenableFuture<>(valueSource);
+        }
+    }
+
+    /**
+     * If we have ValueSourceFuture, we can use it as the implementation and this class only converts
+     * listener registration.
+     */
+    private static class ValueSourceFutureBackedListenableFuture<T> extends FutureWrapper<T> implements ListenableFuture<T> {
+        ValueSourceFutureBackedListenableFuture(ValueSourceFuture<T> valueSourceFuture) {
+            super(valueSourceFuture);
+        }
+
+        @Override
+        protected ValueSourceFuture<T> getWrappedFuture() {
+            return (ValueSourceFuture<T>) super.getWrappedFuture();
+        }
+
+        @Override
+        public void addListener(Runnable listener, Executor executor) {
+            getWrappedFuture().addCallbacks(value -> executor.execute(listener), ex -> executor.execute(listener));
+        }
+    }
+
+
+    /**
+     * If we only get ValueSource we have to create a ValueSourceFuture. Here we wrap Guavas SettableFuture
+     * and use it for listener handling and value storage.
+     */
+    private static class ValueSourceBackedListenableFuture<T> extends FutureWrapper<T> implements ListenableFuture<T> {
+        private final ValueSource<T> valueSource;
+
+        private ValueSourceBackedListenableFuture(ValueSource<T> valueSource) {
+            super(com.google.common.util.concurrent.SettableFuture.create());
+            this.valueSource = valueSource;
+            valueSource.addCallbacks(value -> getWrappedFuture().set(value), ex -> getWrappedFuture().setException(ex));
+        }
+
+        @Override
+        public void addListener(Runnable listener, Executor executor) {
+            getWrappedFuture().addListener(listener, executor);
+        }
+
+        @Override
+        protected com.google.common.util.concurrent.SettableFuture<T> getWrappedFuture() {
+            return (com.google.common.util.concurrent.SettableFuture<T>) super.getWrappedFuture();
+        }
+
+
+        @Override
+        public boolean cancel(boolean mayInterruptIfRunning) {
+            valueSource.cancel(mayInterruptIfRunning);
+            return super.cancel(mayInterruptIfRunning);
+        }
+
+        private ValueSource<T> getValueSource() {
+            return valueSource;
+        }
+    }
+
+
+    // *************************************** Converting from ListenableFuture ******************************************
+    public static <T> ValueSourceFuture<T> createValueSourceFuture(ListenableFuture<T> listenableFuture) {
+        if (listenableFuture instanceof ValueSourceFutureBackedListenableFuture) {
+            return ((ValueSourceFutureBackedListenableFuture<T>) listenableFuture).getWrappedFuture();
+        } else {
+            return new ListenableFutureBackedValueSourceFuture<>(listenableFuture);
+        }
+    }
+
+    public static <T> ValueSource<T> createValueSource(ListenableFuture<T> listenableFuture) {
+        if (listenableFuture instanceof ValueSourceBackedListenableFuture) {
+            return ((ValueSourceBackedListenableFuture<T>) listenableFuture).getValueSource();
+        } else {
+            return new ListenableFutureBackedValueSourceFuture<>(listenableFuture);
+        }
+    }
+
+    /**
+     * Wraps ListenableFuture and exposes it as ValueSourceFuture.
+     */
+    private static class ListenableFutureBackedValueSourceFuture<T> extends ValueSourceFuture<T> {
+        private ListenableFutureBackedValueSourceFuture(ListenableFuture<T> wrappedFuture) {
+            super(wrappedFuture);
+        }
+
+        @Override
+        public void addCallbacks(Consumer<T> successCallback, Consumer<Throwable> failureCallback) {
+            Futures.addCallback(getWrappedFuture(), new FutureCallback<T>() {
+                @Override
+                public void onSuccess(T result) {
+                    successCallback.accept(result);
+                }
+
+                @Override
+                public void onFailure(Throwable t) {
+                    failureCallback.accept(t);
+
+                }
+            }, MoreExecutors.directExecutor());
+        }
+
+
+        @Override
+        protected ListenableFuture<T> getWrappedFuture() {
+            return (ListenableFuture<T>) super.getWrappedFuture();
+        }
+    }
+}

--- a/src/main/java/io/qdrant/client/futureconverter/Java8FutureUtils.java
+++ b/src/main/java/io/qdrant/client/futureconverter/Java8FutureUtils.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright © 2014-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.qdrant.client.futureconverter;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
+
+public class Java8FutureUtils {
+
+    public static <T> CompletableFuture<T> createCompletableFuture(ValueSource<T> valueSource) {
+        if (valueSource instanceof CompletableFuturebackedValueSource) {
+            return ((CompletableFuturebackedValueSource<T>) valueSource).getWrappedFuture();
+        } else {
+            return new ValueSourcebackedCompletableFuture<T>(valueSource);
+        }
+    }
+
+    public static <T> ValueSourceFuture<T> createValueSourceFuture(CompletableFuture<T> completableFuture) {
+        if (completableFuture instanceof ValueSourcebackedCompletableFuture &&
+            ((ValueSourcebackedCompletableFuture<T>) completableFuture).getValueSource() instanceof ValueSourceFuture) {
+            return (ValueSourceFuture<T>) ((ValueSourcebackedCompletableFuture<T>) completableFuture).getValueSource();
+        } else {
+            return new CompletableFuturebackedValueSource<>(completableFuture);
+        }
+    }
+
+    public static <T> ValueSource<T> createValueSource(CompletableFuture<T> completableFuture) {
+        if (completableFuture instanceof ValueSourcebackedCompletableFuture) {
+            return ((ValueSourcebackedCompletableFuture<T>) completableFuture).getValueSource();
+        } else {
+            return new CompletableFuturebackedValueSource<>(completableFuture);
+        }
+    }
+
+    /**
+     * CompletableFuture that takes values from the ValueSource. CompletableFuture is a class, not
+     * an interface so we can not just forward events from the ValueSource, we to always instantiate the class.
+     */
+    private static final class ValueSourcebackedCompletableFuture<T> extends CompletableFuture<T> {
+        private final ValueSource<T> valueSource;
+
+        private ValueSourcebackedCompletableFuture(ValueSource<T> valueSource) {
+            this.valueSource = valueSource;
+            valueSource.addCallbacks(this::complete, this::completeExceptionally);
+        }
+
+        @Override
+        public boolean cancel(boolean mayInterruptIfRunning) {
+            if (isDone()) {
+                return false;
+            }
+            boolean result = valueSource.cancel(mayInterruptIfRunning);
+            super.cancel(mayInterruptIfRunning);
+            return result;
+        }
+
+        private ValueSource<T> getValueSource() {
+            return valueSource;
+        }
+    }
+
+    private static final class CompletableFuturebackedValueSource<T> extends ValueSourceFuture<T> {
+        private CompletableFuturebackedValueSource(CompletableFuture<T> completableFuture) {
+            super(completableFuture);
+        }
+
+
+        @Override
+        public void addCallbacks(Consumer<T> successCallback, Consumer<Throwable> failureCallback) {
+            getWrappedFuture().whenComplete((v, t) -> {
+                if (t == null) {
+                    successCallback.accept(v);
+                } else {
+                    failureCallback.accept(t);
+                }
+            });
+        }
+
+        @Override
+        protected CompletableFuture<T> getWrappedFuture() {
+            return (CompletableFuture<T>) super.getWrappedFuture();
+        }
+    }
+}

--- a/src/main/java/io/qdrant/client/futureconverter/ValueSource.java
+++ b/src/main/java/io/qdrant/client/futureconverter/ValueSource.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2014-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.qdrant.client.futureconverter;
+
+import java.util.function.Consumer;
+
+/**
+ * Source of values. Let's say we are converting from RxJava Single to CompletableFuture. In such case Single is
+ * value source (the original object) and the library registers CompletableFuture (target object) to listen on Singles
+ * events. When someone calls cancel on the CompletableFuture, we want to unsubscribe from the Single, that's why we do
+ * have cancel method here.
+ */
+public interface ValueSource<T> {
+    /**
+     * Used to notify target object about changes in the original object.
+     */
+    void addCallbacks(Consumer<T> successCallback, Consumer<Throwable> failureCallback);
+
+    /**
+     * Cancels execution of the original object if cancel is called on the target object
+     */
+    boolean cancel(boolean mayInterruptIfRunning);
+}

--- a/src/main/java/io/qdrant/client/futureconverter/ValueSourceFuture.java
+++ b/src/main/java/io/qdrant/client/futureconverter/ValueSourceFuture.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright © 2014-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.qdrant.client.futureconverter;
+
+import java.util.concurrent.Future;
+
+/**
+ * Some ValueSources are already futures, let's wrap it and use its implementation.
+ */
+public abstract class ValueSourceFuture<T> extends FutureWrapper<T> implements ValueSource<T> {
+    protected ValueSourceFuture(Future<T> wrappedFuture) {
+        super(wrappedFuture);
+    }
+}

--- a/src/test/java/io/qdrant/client/QdrantClientTest.java
+++ b/src/test/java/io/qdrant/client/QdrantClientTest.java
@@ -3,6 +3,9 @@ package io.qdrant.client;
 import io.grpc.Grpc;
 import io.grpc.InsecureChannelCredentials;
 import io.grpc.ManagedChannel;
+import io.grpc.Status;
+import io.qdrant.client.grpc.Collections;
+import io.qdrant.client.grpc.Points.*;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -10,6 +13,19 @@ import org.junit.jupiter.api.Test;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.qdrant.QdrantContainer;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+import static io.qdrant.client.ConditionFactory.matchKeyword;
+import static io.qdrant.client.PointIdFactory.id;
+import static io.qdrant.client.ValueFactory.value;
+import static io.qdrant.client.VectorsFactory.vectors;
+
+import static io.qdrant.client.WithPayloadSelectorFactory.enable;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @Testcontainers
 class QdrantClientTest {
@@ -36,5 +52,79 @@ class QdrantClientTest {
 	@Test
 	void canAccessChannelOnGrpcClient() {
 		Assertions.assertTrue(client.grpcClient().channel().authority().startsWith("localhost"));
+	}
+
+	@Test
+	void createListDeleteCollectionAsyncReturnsExpectedResponse() {
+		// When
+		CompletableFuture<Collections.CollectionOperationResponse> future = client.createCollectionAsync("test_collection",
+			Collections.VectorParams.newBuilder().setDistance(Collections.Distance.Dot).setSize(4).build());
+
+		// Then
+		// creation
+		assertThat(future).succeedsWithin(Duration.ofMillis(500));
+		assertThat(future).isCompletedWithValueMatching(Collections.CollectionOperationResponse::getResult);
+
+		// list
+		client.listCollectionsAsync().thenCompose(collections -> {
+			assertThat(collections).contains("test_collection");
+
+			// delete
+			return client.deleteCollectionAsync("test_collection");
+		}).thenAccept(response -> {
+			assertThat(response.getResult()).isTrue();
+		});
+	}
+
+	@Test
+	void upsertListDeleteVectorAsyncReturnsExpectedResponse() {
+		// When
+		CompletableFuture<Collections.CollectionOperationResponse> collectionFuture = client.createCollectionAsync("test_collection",
+			Collections.VectorParams.newBuilder().setDistance(Collections.Distance.Dot).setSize(4).build());
+
+		// Then
+		assertThat(collectionFuture).succeedsWithin(Duration.ofMillis(500));
+		assertThat(collectionFuture).isCompletedWithValueMatching(Collections.CollectionOperationResponse::getResult);
+
+		// When
+		CompletableFuture<UpdateResult> vectorFuture = client.upsertAsync("test_collection", List.of(
+			PointStruct.newBuilder().setId(id(1))
+				.setVectors(vectors(0.05f, 0.61f, 0.76f, 0.74f))
+				.putAllPayload(Map.of("city", value("Berlin")))
+				.build(),
+			PointStruct.newBuilder()
+				.setId(id(2))
+				.setVectors(vectors(0.19f, 0.81f, 0.75f, 0.11f))
+				.putAllPayload(Map.of("city", value("London")))
+				.build(),
+			PointStruct.newBuilder()
+				.setId(id(3))
+				.setVectors(vectors(0.36f, 0.55f, 0.47f, 0.94f))
+				.putAllPayload(Map.of("city", value("Moscow")))
+				.build()));
+
+		// Then
+		assertThat(vectorFuture).succeedsWithin(Duration.ofMillis(500));
+		assertThat(vectorFuture).isCompletedWithValueMatching(response -> response.getStatus().equals(UpdateStatus.Completed));
+
+		// When
+		CompletableFuture<List<ScoredPoint>> searchFuture = client.searchAsync(SearchPoints.newBuilder()
+			.setCollectionName("test_collection")
+			.setLimit(3)
+			.setFilter(Filter.newBuilder().addMust(matchKeyword("city", "London")))
+			.addAllVector(List.of(0.2f, 0.1f, 0.9f, 0.7f))
+			.setWithPayload(enable(true))
+			.build());
+
+		// Then
+		assertThat(searchFuture).succeedsWithin(Duration.ofMillis(500));
+		assertThat(searchFuture).isCompletedWithValueMatching(list -> list.size() == 1 && list.get(0).getId().getNum() == 2);
+
+		// When
+		CompletableFuture<UpdateResult> deleteFuture = client.deleteAsync("test_collection", List.of(id(1), id(2), id(3)));
+
+		// Then
+		assertThat(deleteFuture).succeedsWithin(Duration.ofMillis(500));
+		assertThat(deleteFuture).isCompletedWithValueMatching(response -> response.getStatus().equals(UpdateStatus.Completed));
 	}
 }


### PR DESCRIPTION
Hi qdrant team.

Well, this is quite a big PR for a first contribution... all the more so as it introduces a breaking change.
And without even starting a discussion before proposing this PR.
So first of all, I apologize for that.

### Why this PR?

Currently, the `QdrantClient` exposes `ListenableFuture` guava type in its public api. Prior to java 8, the guava library was the only way to implement asynchronous programming in java. Starting with java 8, `CompletionStage` and `CompletableFuture` have been added for that purpose.

Usually, `ListenableFuture` is used when java 6/7 compatibility is required. Since Qdrant java-client requires java 8 minimum, there's nothing preventing the use of `CompletableFuture`. 

I have spent so much time migrating code base from `ListenableFuture` to `CompletableFuture`... I don't want to migrate yet another code base just because a new library exposing `ListenableFuture` is added. So I started to write a wrapper around `QdrantClient` to get rid of `ListenableFuture`.

The goal of this PR is to remove the usage of `ListenableFuture` in the public api of this library. So I can avoid using a wrapper (good for me!) and you will avoid exposing thirdparty library to your public api (good for you!).

### Why not just sticking with ListenableFuture?

`ListenableFuture` tends to be less and less used in favor of `CompletableFuture`. At any time, the guava team may decide to move forward and uses the official api. This change may never happen admittedly, yet [the official guava documentation](https://guava.dev/releases/25.0-jre/api/docs/com/google/common/util/concurrent/FluentFuture.html) is mentioning this eventuality.

For example, the [datastax cassandra client](https://docs.datastax.com/en/developer/java-driver/4.0/upgrade_guide/) library moves from `ListenableFuture` to `CompletableFuture` (version 3 is using `ListenableFuture` while version 4 uses `CompletableFuture`).

The more we wait, the more painful the migration will be.

### How the migration have been done in this PR?

Since [grpc is using `ListenableFuture`](https://github.com/grpc/grpc-java/issues/2797), we have to convert `ListenableFuture` to `CompletableFuture`. The easiest way to do that is to use the [future-converter](https://github.com/lukas-krecan/future-converter) library.

Now, the drawbacks of using this library are the following:
* usually it's better to not depend on new external library
* this library is now archived (no more updates!!)
* the amount of code needed for the conversion is rather small 

To avoid these drawbacks, I have copied and paste code from future-converter in a sub-package. Fortunately, it's the same license!

For the other parts of the migration, I used [this guide](https://gist.github.com/kofemann/a721af324f8c35f6e9840f583ca40f05).

Please not that the guava library is still required at runtime to use your lib. Yet, it is no more exposed in the public api. So guava could be (hypothetically) safely removed without harm in a future version.

### What if this PR is rejected?

It's perfectly fine, no drama! Introducing a breaking change is always a hard choice. 

### I would like to avoid breaking change

Maybe other strategies can be considered, such as adding a new `QdrantClientJava8` while keeping the current one to maintain backwards compatibility (or to ease the migration). This comes with the drawback of having to maintain two versions of the code.

At least, we could use this PR to discuss alternatives.

Thanks for taking the time to read this PR.