### PR TITLE
Add version check on client init

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -100,6 +100,7 @@ dependencies {
 
 	testImplementation "io.grpc:grpc-testing:${grpcVersion}"
 	testImplementation "org.junit.jupiter:junit-jupiter-api:${jUnitVersion}"
+	testImplementation "org.junit.jupiter:junit-jupiter-params:${jUnitVersion}"
 	testImplementation "org.mockito:mockito-core:3.4.0"
 	testImplementation "org.slf4j:slf4j-nop:${slf4jVersion}"
 	testImplementation "org.testcontainers:qdrant:${testcontainersVersion}"

--- a/src/main/java/io/qdrant/client/QdrantGrpcClient.java
+++ b/src/main/java/io/qdrant/client/QdrantGrpcClient.java
@@ -286,12 +286,12 @@ public class QdrantGrpcClient implements AutoCloseable {
                   + " is incompatible with server version "
                   + serverVersion
                   + ". Major versions should match and minor version difference must not exceed 1. "
-                  + "Set check_version=False to skip version check.";
+                  + "Set checkCompatibility=false to skip version check.";
           logger.warn(logMessage);
         }
       } catch (Exception e) {
         logger.warn(
-            "Failed to obtain server version. Unable to check client-server compatibility. Set checkCompatibility=False to skip version check.");
+            "Failed to obtain server version. Unable to check client-server compatibility. Set checkCompatibility=false to skip version check.");
       }
     }
   }

--- a/src/main/java/io/qdrant/client/QdrantGrpcClient.java
+++ b/src/main/java/io/qdrant/client/QdrantGrpcClient.java
@@ -280,16 +280,17 @@ public class QdrantGrpcClient implements AutoCloseable {
                 .healthCheck(QdrantOuterClass.HealthCheckRequest.getDefaultInstance())
                 .getVersion();
         if (!VersionsCompatibilityChecker.isCompatible(clientVersion, serverVersion)) {
-          System.out.println(
+          String logMessage =
               "Qdrant client version "
                   + clientVersion
                   + " is incompatible with server version "
                   + serverVersion
                   + ". Major versions should match and minor version difference must not exceed 1. "
-                  + "Set check_version=False to skip version check.");
+                  + "Set check_version=False to skip version check.";
+          logger.warn(logMessage);
         }
       } catch (Exception e) {
-        System.out.println(
+        logger.warn(
             "Failed to obtain server version. Unable to check client-server compatibility. Set checkCompatibility=False to skip version check.");
       }
     }

--- a/src/main/java/io/qdrant/client/VersionsCompatibilityChecker.java
+++ b/src/main/java/io/qdrant/client/VersionsCompatibilityChecker.java
@@ -1,0 +1,96 @@
+package io.qdrant.client;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class Version {
+  private final int major;
+  private final int minor;
+  private final String rest;
+
+  public Version(int major, int minor, String rest) {
+    this.major = major;
+    this.minor = minor;
+    this.rest = rest;
+  }
+
+  public int getMajor() {
+    return major;
+  }
+
+  public int getMinor() {
+    return minor;
+  }
+
+  public String getRest() {
+    return rest;
+  }
+}
+
+/** Utility class to check compatibility between server's and client's versions. */
+public class VersionsCompatibilityChecker {
+  private static final Logger logger = LoggerFactory.getLogger(VersionsCompatibilityChecker.class);
+
+  /** Default constructor. */
+  public VersionsCompatibilityChecker() {}
+
+  private static Version parseVersion(String version) throws IllegalArgumentException {
+    if (version.isEmpty()) {
+      throw new IllegalArgumentException("Version is None");
+    }
+
+    try {
+      String[] parts = version.split("\\.");
+      int major = parts.length > 0 ? Integer.parseInt(parts[0]) : 0;
+      int minor = parts.length > 1 ? Integer.parseInt(parts[1]) : 0;
+      String rest =
+          parts.length > 2
+              ? String.join(".", new ArrayList<>(Arrays.asList(parts).subList(2, parts.length)))
+              : "";
+
+      return new Version(major, minor, rest);
+    } catch (Exception e) {
+      throw new IllegalArgumentException(
+          "Unable to parse version, expected format: x.y.z, found: " + version, e);
+    }
+  }
+
+  /**
+   * Compares server's and client's versions.
+   *
+   * @param clientVersion The client's version.
+   * @param serverVersion The server's version.
+   * @return True if the versions are compatible, false otherwise.
+   */
+  public static boolean isCompatible(String clientVersion, String serverVersion) {
+    if (clientVersion.isEmpty()) {
+      logger.warn("Unable to compare with client version {}", clientVersion);
+      return false;
+    }
+
+    if (serverVersion.isEmpty()) {
+      logger.warn("Unable to compare with server version {}", serverVersion);
+      return false;
+    }
+
+    if (clientVersion.equals(serverVersion)) {
+      return true;
+    }
+
+    try {
+      Version parsedServerVersion = parseVersion(serverVersion);
+      Version parsedClientVersion = parseVersion(clientVersion);
+
+      int majorDiff = Math.abs(parsedServerVersion.getMajor() - parsedClientVersion.getMajor());
+      if (majorDiff >= 1) {
+        return false;
+      }
+      return Math.abs(parsedServerVersion.getMinor() - parsedClientVersion.getMinor()) <= 1;
+    } catch (IllegalArgumentException e) {
+      logger.warn("Unable to compare versions: {}", e.getMessage());
+      return false;
+    }
+  }
+}

--- a/src/main/java/io/qdrant/client/VersionsCompatibilityChecker.java
+++ b/src/main/java/io/qdrant/client/VersionsCompatibilityChecker.java
@@ -1,19 +1,15 @@
 package io.qdrant.client;
 
-import java.util.ArrayList;
-import java.util.Arrays;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 class Version {
   private final int major;
   private final int minor;
-  private final String rest;
 
-  public Version(int major, int minor, String rest) {
+  public Version(int major, int minor) {
     this.major = major;
     this.minor = minor;
-    this.rest = rest;
   }
 
   public int getMajor() {
@@ -22,10 +18,6 @@ class Version {
 
   public int getMinor() {
     return minor;
-  }
-
-  public String getRest() {
-    return rest;
   }
 }
 
@@ -45,15 +37,11 @@ public class VersionsCompatibilityChecker {
       String[] parts = version.split("\\.");
       int major = parts.length > 0 ? Integer.parseInt(parts[0]) : 0;
       int minor = parts.length > 1 ? Integer.parseInt(parts[1]) : 0;
-      String rest =
-          parts.length > 2
-              ? String.join(".", new ArrayList<>(Arrays.asList(parts).subList(2, parts.length)))
-              : "";
 
-      return new Version(major, minor, rest);
+      return new Version(major, minor);
     } catch (Exception e) {
       throw new IllegalArgumentException(
-          "Unable to parse version, expected format: x.y.z, found: " + version, e);
+          "Unable to parse version, expected format: x.y[.z], found: " + version, e);
     }
   }
 
@@ -65,31 +53,15 @@ public class VersionsCompatibilityChecker {
    * @return True if the versions are compatible, false otherwise.
    */
   public static boolean isCompatible(String clientVersion, String serverVersion) {
-    if (clientVersion.isEmpty()) {
-      logger.warn("Unable to compare with client version {}", clientVersion);
-      return false;
-    }
-
-    if (serverVersion.isEmpty()) {
-      logger.warn("Unable to compare with server version {}", serverVersion);
-      return false;
-    }
-
-    if (clientVersion.equals(serverVersion)) {
-      return true;
-    }
-
     try {
-      Version parsedServerVersion = parseVersion(serverVersion);
-      Version parsedClientVersion = parseVersion(clientVersion);
+      Version client = parseVersion(clientVersion);
+      Version server = parseVersion(serverVersion);
 
-      int majorDiff = Math.abs(parsedServerVersion.getMajor() - parsedClientVersion.getMajor());
-      if (majorDiff >= 1) {
-        return false;
-      }
-      return Math.abs(parsedServerVersion.getMinor() - parsedClientVersion.getMinor()) <= 1;
+      if (client.getMajor() != server.getMajor()) return false;
+      return Math.abs(client.getMinor() - server.getMinor()) <= 1;
+
     } catch (IllegalArgumentException e) {
-      logger.warn("Unable to compare versions: {}", e.getMessage());
+      logger.warn("Version comparison failed: {}", e.getMessage());
       return false;
     }
   }

--- a/src/test/java/io/qdrant/client/VersionsCompatibilityCheckerTest.java
+++ b/src/test/java/io/qdrant/client/VersionsCompatibilityCheckerTest.java
@@ -43,9 +43,7 @@ public class VersionsCompatibilityCheckerTest {
     Method method =
         VersionsCompatibilityChecker.class.getDeclaredMethod("parseVersion", String.class);
     method.setAccessible(true);
-    assertThrows(
-        InvocationTargetException.class,
-        () -> method.invoke(null, versionStr));
+    assertThrows(InvocationTargetException.class, () -> method.invoke(null, versionStr));
   }
 
   private static Stream<Object[]> versionCompatibilityProvider() {

--- a/src/test/java/io/qdrant/client/VersionsCompatibilityCheckerTest.java
+++ b/src/test/java/io/qdrant/client/VersionsCompatibilityCheckerTest.java
@@ -12,17 +12,16 @@ import org.junit.jupiter.params.provider.MethodSource;
 public class VersionsCompatibilityCheckerTest {
   private static Stream<Object[]> validVersionProvider() {
     return Stream.of(
-        new Object[] {"1.2.3", 1, 2, "3"},
-        new Object[] {"1.2.3-alpha", 1, 2, "3-alpha"},
-        new Object[] {"1.2", 1, 2, ""},
-        new Object[] {"1", 1, 0, ""},
-        new Object[] {"1.", 1, 0, ""});
+        new Object[] {"1.2.3", 1, 2},
+        new Object[] {"1.2.3-alpha", 1, 2},
+        new Object[] {"1.2", 1, 2},
+        new Object[] {"1", 1, 0},
+        new Object[] {"1.", 1, 0});
   }
 
   @ParameterizedTest
   @MethodSource("validVersionProvider")
-  public void testParseVersion_validVersion(
-      String versionStr, int expectedMajor, int expectedMinor, String expectedRest)
+  public void testParseVersion_validVersion(String versionStr, int expectedMajor, int expectedMinor)
       throws Exception {
     Method method =
         VersionsCompatibilityChecker.class.getDeclaredMethod("parseVersion", String.class);
@@ -30,7 +29,6 @@ public class VersionsCompatibilityCheckerTest {
     Version version = (Version) method.invoke(null, versionStr);
     assertEquals(expectedMajor, version.getMajor());
     assertEquals(expectedMinor, version.getMinor());
-    assertEquals(expectedRest, version.getRest());
   }
 
   private static Stream<String> invalidVersionProvider() {

--- a/src/test/java/io/qdrant/client/VersionsCompatibilityCheckerTest.java
+++ b/src/test/java/io/qdrant/client/VersionsCompatibilityCheckerTest.java
@@ -1,0 +1,75 @@
+package io.qdrant.client;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class VersionsCompatibilityCheckerTest {
+  private static Stream<Object[]> validVersionProvider() {
+    return Stream.of(
+        new Object[] {"1.2.3", 1, 2, "3"},
+        new Object[] {"1.2.3-alpha", 1, 2, "3-alpha"},
+        new Object[] {"1.2", 1, 2, ""},
+        new Object[] {"1", 1, 0, ""},
+        new Object[] {"1.", 1, 0, ""});
+  }
+
+  @ParameterizedTest
+  @MethodSource("validVersionProvider")
+  public void testParseVersion_validVersion(
+      String versionStr, int expectedMajor, int expectedMinor, String expectedRest)
+      throws Exception {
+    Method method =
+        VersionsCompatibilityChecker.class.getDeclaredMethod("parseVersion", String.class);
+    method.setAccessible(true);
+    Version version = (Version) method.invoke(null, versionStr);
+    assertEquals(expectedMajor, version.getMajor());
+    assertEquals(expectedMinor, version.getMinor());
+    assertEquals(expectedRest, version.getRest());
+  }
+
+  private static Stream<String> invalidVersionProvider() {
+    return Stream.of("v1.12.0", "", ".1", ".1.", "1.null.1", "null.0.1", null);
+  }
+
+  @ParameterizedTest
+  @MethodSource("invalidVersionProvider")
+  public void testParseVersion_invalidVersion(String versionStr) throws Exception {
+    Method method =
+        VersionsCompatibilityChecker.class.getDeclaredMethod("parseVersion", String.class);
+    method.setAccessible(true);
+    assertThrows(
+        InvocationTargetException.class,
+        () -> method.invoke(null, versionStr));
+  }
+
+  private static Stream<Object[]> versionCompatibilityProvider() {
+    return Stream.of(
+        new Object[] {"1.9.3.dev0", "2.8.1.dev12-something", false},
+        new Object[] {"1.9", "2.8", false},
+        new Object[] {"1", "2", false},
+        new Object[] {"1.9.0", "2.9.0", false},
+        new Object[] {"1.1.0", "1.2.9", true},
+        new Object[] {"1.2.7", "1.1.8.dev0", true},
+        new Object[] {"1.2.1", "1.2.29", true},
+        new Object[] {"1.2.0", "1.2.0", true},
+        new Object[] {"1.2.0", "1.4.0", false},
+        new Object[] {"1.4.0", "1.2.0", false},
+        new Object[] {"1.9.0", "3.7.0", false},
+        new Object[] {"3.0.0", "1.0.0", false},
+        new Object[] {"", "1.0.0", false},
+        new Object[] {"1.0.0", "", false},
+        new Object[] {"", "", false});
+  }
+
+  @ParameterizedTest
+  @MethodSource("versionCompatibilityProvider")
+  public void testIsCompatible(String clientVersion, String serverVersion, boolean expected) {
+    assertEquals(expected, VersionsCompatibilityChecker.isCompatible(clientVersion, serverVersion));
+  }
+}


### PR DESCRIPTION
Send request to fetch server version during client init and compare with client version.

Introduce an optional `checkCompatibility` param (true by default). If it is true -> check versions during client init and generate a warning if versions are not compatible. Compatible versions are the ones that differ by one, i.e client version 1.6.x is compatible with server versions 1.5.x and 1.7.x but not 1.4.x or 1.8.x.