### PR TITLE
WIP: Handle retry-after header

### DIFF
--- a/src/main/java/io/qdrant/client/QdrantGrpcClient.java
+++ b/src/main/java/io/qdrant/client/QdrantGrpcClient.java
@@ -269,6 +269,7 @@ public class QdrantGrpcClient implements AutoCloseable {
       }
 
       channelBuilder.userAgent(userAgent);
+      channelBuilder.intercept(new ResourceExhaustedInterceptor());
 
       return channelBuilder.build();
     }

--- a/src/main/java/io/qdrant/client/ResourceExhaustedInterceptor.java
+++ b/src/main/java/io/qdrant/client/ResourceExhaustedInterceptor.java
@@ -1,0 +1,49 @@
+package io.qdrant.client;
+
+import io.grpc.*;
+
+/** An Interceptor that handles Resource Exhausted errors */
+public class ResourceExhaustedInterceptor implements ClientInterceptor {
+  /** Default constructor for {@link ResourceExhaustedInterceptor} */
+  public ResourceExhaustedInterceptor() {}
+
+  @Override
+  public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
+      MethodDescriptor<ReqT, RespT> method, CallOptions callOptions, Channel next) {
+    return new ForwardingClientCall.SimpleForwardingClientCall<ReqT, RespT>(
+        next.newCall(method, callOptions)) {
+
+      @Override
+      public void start(Listener<RespT> responseListener, Metadata headers) {
+        super.start(
+            new ForwardingClientCallListener.SimpleForwardingClientCallListener<RespT>(
+                responseListener) {
+              @Override
+              public void onClose(Status status, Metadata trailers) {
+                if (status.getCode() == Status.Code.RESOURCE_EXHAUSTED) {
+                  String retryAfter =
+                      trailers.get(
+                          Metadata.Key.of("Retry-After", Metadata.ASCII_STRING_MARSHALLER));
+                  if (retryAfter != null) {
+                    try {
+                      int retryAfterSeconds = Integer.parseInt(retryAfter);
+                      status =
+                          status.withCause(
+                              new ResourceExhaustedResponse(
+                                  "Too many requests", retryAfterSeconds));
+                    } catch (NumberFormatException e) {
+                      throw new QdrantException(
+                          "Retry-After header value is not a valid integer: " + retryAfter);
+                    }
+                  } else {
+                    super.onClose(status, trailers);
+                  }
+                }
+                super.onClose(status, trailers);
+              }
+            },
+            headers);
+      }
+    };
+  }
+}

--- a/src/main/java/io/qdrant/client/ResourceExhaustedResponse.java
+++ b/src/main/java/io/qdrant/client/ResourceExhaustedResponse.java
@@ -1,0 +1,27 @@
+package io.qdrant.client;
+
+/** An exception indicating that rate limit is reached */
+public class ResourceExhaustedResponse extends RuntimeException {
+  /** The number of seconds to wait before retrying */
+  private final int retryAfterSeconds;
+
+  /**
+   * Instantiates a new instance of {@link ResourceExhaustedResponse}
+   *
+   * @param message The message to display
+   * @param retryAfterSeconds The number of seconds to wait before retrying
+   */
+  public ResourceExhaustedResponse(String message, int retryAfterSeconds) {
+    super(message);
+    this.retryAfterSeconds = retryAfterSeconds;
+  }
+
+  /**
+   * Gets the number of seconds to wait before retrying
+   *
+   * @return the number of seconds to wait before retrying
+   */
+  public int getRetryAfterSeconds() {
+    return retryAfterSeconds;
+  }
+}


### PR DESCRIPTION
Add support for following responses from Qdrant:

Rate limiter hit for gRPC: https://github.com/qdrant/qdrant/pull/6072

Usage example for strict mode ("read_rate_limit": 60, "write_rate_limit": 60):

```
package org.example;

import io.grpc.StatusRuntimeException;
import io.qdrant.client.QdrantClient;
import io.qdrant.client.QdrantGrpcClient;
import io.qdrant.client.ResourceExhaustedException;
import io.qdrant.client.grpc.Points;

import java.util.List;
import java.util.concurrent.ExecutionException;

public class Main {
    public static void hitRateLimit(QdrantClient qClient) {
        System.out.println("start hitRateLimit");
        for (int i = 0; i < 100; i++) {
            try {
                List<Points.ScoredPoint> points =
                  qClient
                    .searchAsync(
                      Points.SearchPoints.newBuilder()
                        .setCollectionName("benchmark")
                        .addAllVector(List.of(0.6235f, 0.123f, 0.532f, 0.123f))
                        .setLimit(5)
                        .build())
                    .get();
            } catch (ExecutionException | InterruptedException | StatusRuntimeException e) {
                    System.out.println("Exception caught: " + e.getMessage());
                    if (e.getCause() instanceof ResourceExhaustedException) {
                        ResourceExhaustedException ex = (ResourceExhaustedException) e.getCause();
                        System.out.println("hitRateLimit! retry after" + ex.getRetryAfterSeconds());
                        break;
                    }
                    break;
                }
        }
        System.out.println("done hitRateLimit");
    }

    public static void main(String[] args) {
        QdrantClient client = new QdrantClient(QdrantGrpcClient.newBuilder("localhost", 6334, false, true).build());

        String collectionName = "benchmark";

        try {
            client.healthCheckAsync().get();
            boolean collectionExists = client.collectionExistsAsync(collectionName).get();

            if (collectionExists) {
                System.out.println("Collection exists: " + collectionName);
            } else {
                System.out.println("Collection does not exist: " + collectionName);
            }
        } catch (Exception e) {
            System.err.println("Error checking collection: " + e.getMessage());
        }

        hitRateLimit(client);
    }
}
```