### PR TITLE
ci: Bump actions/upload-artifact to v4

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -46,7 +46,7 @@ jobs:
           report_paths: '**/build/test-results/test/TEST-*.xml'
 
       - name: Upload Jars
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: QdrantJava
           path: build/libs


### PR DESCRIPTION
To resolve https://github.com/qdrant/java-client/actions/runs/14595688256.