### PR TITLE
ci: Updated publishing config

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -236,8 +236,8 @@ publishing {
 nexusPublishing {
     repositories {
         sonatype {
-            nexusUrl = uri("https://s01.oss.sonatype.org/service/local/")
-            snapshotRepositoryUrl = uri("https://s01.oss.sonatype.org/content/repositories/snapshots/")
+            nexusUrl = uri("https://ossrh-staging-api.central.sonatype.com/service/local/")
+            snapshotRepositoryUrl = uri("https://central.sonatype.com/repository/maven-snapshots/")
         }
     }
 }


### PR DESCRIPTION
Our current publishing repository(OSSRH) has been sunset.
https://central.sonatype.org/news/20250326_ossrh_sunset/

So we have to migrate to the new Central Publisher Portal - https://central.sonatype.com/.
There's a simple way to migrate to the new repository without much changes to our CI. Using https://central.sonatype.org/publish/publish-portal-ossrh-staging-api/#getting-started-for-nexus-repository-manager-2-api-plugins (OSSRH staging API by Central Publisher Portal)

~TODO: UPDATE CREDENTIALS~