### PR TITLE
Update base docker images

### DIFF
--- a/example/Dockerfile
+++ b/example/Dockerfile
@@ -1,5 +1,5 @@
 # Use OpenJDK 11 as base image
-FROM openjdk:11-jdk-slim AS build
+FROM eclipse-temurin:11-jdk AS build
 
 # Set working directory
 WORKDIR /app
@@ -24,7 +24,7 @@ COPY . .
 RUN gradle --no-daemon clean shadowJar
 
 # Create a runtime image
-FROM openjdk:11-jre-slim
+FROM eclipse-temurin:11-jre
 
 WORKDIR /app
 


### PR DESCRIPTION
The OpenJDK Docker image tags `11-jdk-slim` and `11-jre-slim`, used in the client example Dockerfile, were [deleted recently](https://github.com/docker-library/openjdk/pull/550). The [advice](https://github.com/docker-library/openjdk/pull/550#issuecomment-3488053552) shared on the PR that removed those tags is to [use `eclipse-temurin` images instead](https://hub.docker.com/_/eclipse-temurin). 

This PR switches the base images to `eclipse-temurin:11-jdk` and `eclipse-temurin:11-jre`