### PR TITLE
feat: Add option to skip TLS certificate verification

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -96,7 +96,7 @@ dependencies {
 
 	errorprone "com.google.errorprone:error_prone_core:2.29.2"
 
-	runtimeOnly "io.grpc:grpc-netty-shaded:${grpcVersion}"
+	implementation "io.grpc:grpc-netty-shaded:${grpcVersion}"
 
 	testImplementation "io.grpc:grpc-testing:${grpcVersion}"
 	testImplementation "org.junit.jupiter:junit-jupiter-api:${jUnitVersion}"

--- a/src/main/java/io/qdrant/client/TlsSkipVerifyChannelBuilder.java
+++ b/src/main/java/io/qdrant/client/TlsSkipVerifyChannelBuilder.java
@@ -1,0 +1,31 @@
+package io.qdrant.client;
+
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.netty.shaded.io.grpc.netty.GrpcSslContexts;
+import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder;
+import io.grpc.netty.shaded.io.netty.handler.ssl.util.InsecureTrustManagerFactory;
+import javax.net.ssl.SSLException;
+
+/** Represents a builder for a channel that skips TLS verification. */
+public class TlsSkipVerifyChannelBuilder {
+
+  private TlsSkipVerifyChannelBuilder() {}
+
+  /**
+   * build a channel that skips TLS verification
+   *
+   * @param builder the builder to configure
+   */
+  public static void build(ManagedChannelBuilder<?> builder) {
+    if (!(builder instanceof NettyChannelBuilder)) {
+      return;
+    }
+    try {
+      NettyChannelBuilder nettyChannelBuilder = (NettyChannelBuilder) builder;
+      nettyChannelBuilder.sslContext(
+          GrpcSslContexts.forClient().trustManager(InsecureTrustManagerFactory.INSTANCE).build());
+    } catch (SSLException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}


### PR DESCRIPTION
#### Summary

This pull request introduces a new configuration option to **skip TLS certificate verification** when creating a `QdrantGrpcClient`. This is useful for development and testing environments where self-signed or untrusted certificates may be used.

#### Key Changes

- Added a new `skipTlsCheck` boolean flag to:
  - `QdrantGrpcClient.newBuilder(...)`
  - `QdrantGrpcClient.Builder` constructors
- Updated underlying channel creation logic to disable TLS certificate verification when `skipTlsCheck = true`
  - Uses `TlsSkipVerifyChannelBuilder` to configure the channel
- Maintains default behavior (`skipTlsCheck = false`) to ensure secure connections by default

#### Motivation

Some users run Qdrant in internal or testing environments where TLS is enabled but certificate validation is unnecessary or would cause connectivity failures (e.g., using self-signed certificates). This option provides flexibility while keeping security intact in production scenarios.

#### Usage Example

```
QdrantGrpcClient client =
    QdrantGrpcClient.newBuilder(
        "localhost",
        6334,
        true,  // TLS enabled
        true,  // Compatibility checks enabled
        true   // Skip TLS certificate verification
    ).build();
```

> ⚠️ **Warning**
>  Disabling certificate verification should only be used for **testing** or **trusted networks**, as it may expose the connection to MITM attacks.