### PR TITLE
ci: update third-party actions to node 24

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -29,19 +29,19 @@ jobs:
         run: echo "api.version=1.44" > $HOME/.docker-java.properties
 
       - name: Build
-        uses: gradle/gradle-build-action@a8f75513eafdebd8141bd1cd4e30fcd194af8dfa # v2.12.0
+        uses: gradle/gradle-build-action@ac2d340dc04d9e1113182899e983b5400c17cda1 # v3.5.0
         with:
           gradle-version: 8.5
           arguments: build
 
       - name: Test
-        uses: gradle/gradle-build-action@a8f75513eafdebd8141bd1cd4e30fcd194af8dfa # v2.12.0
+        uses: gradle/gradle-build-action@ac2d340dc04d9e1113182899e983b5400c17cda1 # v3.5.0
         with:
           gradle-version: 8.5
           arguments: test --info
 
       - name: Test Results
-        uses: mikepenz/action-junit-report@db71d41eb79864e25ab0337e395c352e84523afe # v4.3.1
+        uses: mikepenz/action-junit-report@3a81627bfac62268172037048872e8ebd4207e6d # v6.4.1
         if: always()
         with:
           fail_on_failure: true
@@ -77,7 +77,7 @@ jobs:
         run: echo "api.version=1.44" > $HOME/.docker-java.properties
 
       - name: Publish package
-        uses: gradle/gradle-build-action@a8f75513eafdebd8141bd1cd4e30fcd194af8dfa # v2.12.0
+        uses: gradle/gradle-build-action@ac2d340dc04d9e1113182899e983b5400c17cda1 # v3.5.0
         with:
           gradle-version: 8.5
           arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,13 +31,13 @@ jobs:
         run: echo "api.version=1.44" > $HOME/.docker-java.properties
 
       - name: Build
-        uses: gradle/gradle-build-action@a8f75513eafdebd8141bd1cd4e30fcd194af8dfa # v2.12.0
+        uses: gradle/gradle-build-action@ac2d340dc04d9e1113182899e983b5400c17cda1 # v3.5.0
         with:
           gradle-version: 8.5
           arguments: build --info
 
       - name: Test
-        uses: gradle/gradle-build-action@a8f75513eafdebd8141bd1cd4e30fcd194af8dfa # v2.12.0
+        uses: gradle/gradle-build-action@ac2d340dc04d9e1113182899e983b5400c17cda1 # v3.5.0
         with:
           gradle-version: 8.5
           arguments: test --info


### PR DESCRIPTION
Update all third-party GitHub Actions to Node 24-compatible versions before the June 2 deadline.