### PR TITLE
docs: use {@code} instead of {@link} for primitive types in factory Javadoc

### DIFF
--- a/src/main/java/io/qdrant/client/PointIdFactory.java
+++ b/src/main/java/io/qdrant/client/PointIdFactory.java
@@ -8,7 +8,7 @@ public final class PointIdFactory {
   private PointIdFactory() {}
 
   /**
-   * Creates a point id from a {@link long}
+   * Creates a point id from a {@code long}
    *
    * @param id The id
    * @return a new instance of {@link PointId}

--- a/src/main/java/io/qdrant/client/QueryFactory.java
+++ b/src/main/java/io/qdrant/client/QueryFactory.java
@@ -162,7 +162,7 @@ public final class QueryFactory {
   }
 
   /**
-   * Creates a {@link Query} from a {@link long}
+   * Creates a {@link Query} from a {@code long}
    *
    * @param id The point id
    * @return a new instance of {@link Query}

--- a/src/main/java/io/qdrant/client/StartFromFactory.java
+++ b/src/main/java/io/qdrant/client/StartFromFactory.java
@@ -9,7 +9,7 @@ public final class StartFromFactory {
   private StartFromFactory() {}
 
   /**
-   * Creates a {@link StartFrom} value from a {@link float}
+   * Creates a {@link StartFrom} value from a {@code float}
    *
    * @param value The value
    * @return a new instance of {@link StartFrom}
@@ -19,7 +19,7 @@ public final class StartFromFactory {
   }
 
   /**
-   * Creates a {@link StartFrom} value from a {@link int}
+   * Creates a {@link StartFrom} value from a {@code int}
    *
    * @param value The value
    * @return a new instance of {@link StartFrom}

--- a/src/main/java/io/qdrant/client/ValueFactory.java
+++ b/src/main/java/io/qdrant/client/ValueFactory.java
@@ -22,7 +22,7 @@ public final class ValueFactory {
   }
 
   /**
-   * Creates a value from a {@link long}
+   * Creates a value from a {@code long}
    *
    * @param value The value
    * @return a new instance of {@link io.qdrant.client.grpc.JsonWithInt.Value}
@@ -32,7 +32,7 @@ public final class ValueFactory {
   }
 
   /**
-   * Creates a value from a {@link double}
+   * Creates a value from a {@code double}
    *
    * @param value The value
    * @return a new instance of {@link io.qdrant.client.grpc.JsonWithInt.Value}
@@ -42,7 +42,7 @@ public final class ValueFactory {
   }
 
   /**
-   * Creates a value from a {@link boolean}
+   * Creates a value from a {@code boolean}
    *
    * @param value The value
    * @return a new instance of {@link io.qdrant.client.grpc.JsonWithInt.Value}

--- a/src/main/java/io/qdrant/client/VectorInputFactory.java
+++ b/src/main/java/io/qdrant/client/VectorInputFactory.java
@@ -88,7 +88,7 @@ public final class VectorInputFactory {
   }
 
   /**
-   * Creates a {@link VectorInput} from a {@link long}
+   * Creates a {@link VectorInput} from a {@code long}
    *
    * @param id The point id
    * @return a new instance of {@link VectorInput}


### PR DESCRIPTION
## What

Several factory classes document primitive parameter/source types with `{@link long}`, `{@link int}`, `{@link double}`, `{@link boolean}`, and `{@link float}`.

`{@link}` requires a reference to a program element (a class, method, or field), so it cannot resolve a primitive type. As written, these tags emit `reference not found` Javadoc warnings and render as broken links in the published API reference at https://qdrant.github.io/java-client.

This replaces `{@link <primitive>}` with `{@code <primitive>}`, the correct tag for rendering a primitive type name as inline code. Genuine class references (e.g. `{@link Query}`, `{@link StartFrom}`, `{@link VectorInput}`, `{@link String}`) are left unchanged.

## Why

- `CONTRIBUTING.md` asks that code build with no warnings and that docstrings be appropriate, since the API reference is published.
- Removes 8 Javadoc warnings and fixes the corresponding broken links in the published docs.

## Changes

8 occurrences across 5 files (comment-only, no behavior or API change):

- `PointIdFactory` — point id from `long`
- `QueryFactory` — query from `long`
- `StartFromFactory` — start-from from `float` and `int`
- `ValueFactory` — value from `long`, `double`, `boolean`
- `VectorInputFactory` — vector input from `long`