### PR TITLE
chore: Bump version to 1.18.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,20 +38,20 @@ To install the library, add the following lines to your build config file.
 <dependency>
   <groupId>io.qdrant</groupId>
   <artifactId>client</artifactId>
-  <version>1.18.1</version>
+  <version>1.18.2</version>
 </dependency>
 ```
 
 #### SBT
 
 ```sbt
-libraryDependencies += "io.qdrant" % "client" % "1.18.1"
+libraryDependencies += "io.qdrant" % "client" % "1.18.2"
 ```
 
 #### Gradle
 
 ```gradle
-implementation 'io.qdrant:client:1.18.1'
+implementation 'io.qdrant:client:1.18.2'
 ```
 
 > [!NOTE]  

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -13,7 +13,7 @@ repositories {
 
 dependencies {
     // Qdrant Java client
-    implementation 'io.qdrant:client:1.18.1'
+    implementation 'io.qdrant:client:1.18.2'
     
     // gRPC dependencies - use the same version as Qdrant client
     implementation 'io.grpc:grpc-netty-shaded:1.65.1'

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,4 +5,4 @@ qdrantProtosVersion=v1.18.0
 qdrantVersion=v1.18.0
 
 # The version of the client to generate
-packageVersion=1.18.1
+packageVersion=1.18.2


### PR DESCRIPTION
## To Relase The Following

* ci: update GitHub Actions to Node 24 before June 2 deadline by @estebany-qd in https://github.com/qdrant/java-client/pull/112
* ci: update third-party actions to node 24 by @estebany-qd in https://github.com/qdrant/java-client/pull/113
* chore: add Dependabot configuration by @andres-qd in https://github.com/qdrant/java-client/pull/114
* chore(deps): bump actions/checkout from 6.0.2 to 6.0.3 in the version-updates group by @dependabot[bot] in https://github.com/qdrant/java-client/pull/115
* chore(deps): bump io.github.gradle-nexus.publish-plugin from 1.3.0 to 2.0.0 by @dependabot[bot] in https://github.com/qdrant/java-client/pull/118
* chore(deps): bump org.mockito:mockito-core from 3.4.0 to 5.23.0 by @dependabot[bot] in https://github.com/qdrant/java-client/pull/120
* chore(deps): bump net.ltgt.errorprone from 3.1.0 to 5.1.0 by @dependabot[bot] in https://github.com/qdrant/java-client/pull/119
* chore(deps): bump jUnitVersion from 5.10.2 to 6.1.0 by @dependabot[bot] in https://github.com/qdrant/java-client/pull/117
* chore(deps): bump the version-updates group across 1 directory with 14 updates by @dependabot[bot] in https://github.com/qdrant/java-client/pull/116
* chore(deps): bump the version-updates group with 6 updates by @dependabot[bot] in https://github.com/qdrant/java-client/pull/121
* chore(deps): bump gradle-wrapper from 8.5 to 9.5.1 by @dependabot[bot] in https://github.com/qdrant/java-client/pull/123
* chore(deps): bump com.diffplug.spotless from 6.22.0 to 8.6.0 by @dependabot[bot] in https://github.com/qdrant/java-client/pull/124
* chore(deps): bump actions/setup-java from 5.2.0 to 5.3.0 in the version-updates group by @dependabot[bot] in https://github.com/qdrant/java-client/pull/125
* chore(deps): bump actions/checkout from 6.0.3 to 7.0.0 by @dependabot[bot] in https://github.com/qdrant/java-client/pull/126
* chore(deps): bump the version-updates group with 3 updates by @dependabot[bot] in https://github.com/qdrant/java-client/pull/127
* docs: use {@code} instead of {@link} for primitive types in factory Javadoc by @dhruv-15-03 in https://github.com/qdrant/java-client/pull/128