### PR TITLE
fix: run version compatibility check with the resolved API key credentials

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Set up JDK 21
         uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0
@@ -65,7 +65,7 @@ jobs:
       ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.ORG_GRADLE_PROJECT_SONATYPEPASSWORD }}
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Set up JDK 21
         uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0

--- a/README.md
+++ b/README.md
@@ -38,20 +38,20 @@ To install the library, add the following lines to your build config file.
 <dependency>
   <groupId>io.qdrant</groupId>
   <artifactId>client</artifactId>
-  <version>1.18.2</version>
+  <version>1.18.3</version>
 </dependency>
 ```
 
 #### SBT
 
 ```sbt
-libraryDependencies += "io.qdrant" % "client" % "1.18.2"
+libraryDependencies += "io.qdrant" % "client" % "1.18.3"
 ```
 
 #### Gradle
 
 ```gradle
-implementation 'io.qdrant:client:1.18.2'
+implementation 'io.qdrant:client:1.18.3'
 ```
 
 > [!NOTE]  

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -13,7 +13,7 @@ repositories {
 
 dependencies {
     // Qdrant Java client
-    implementation 'io.qdrant:client:1.18.2'
+    implementation 'io.qdrant:client:1.18.3'
     
     // gRPC dependencies - use the same version as Qdrant client
     implementation 'io.grpc:grpc-netty-shaded:1.65.1'

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,4 +5,4 @@ qdrantProtosVersion=v1.18.0
 qdrantVersion=v1.18.0
 
 # The version of the client to generate
-packageVersion=1.18.2
+packageVersion=1.18.3

--- a/src/main/java/io/qdrant/client/QdrantGrpcClient.java
+++ b/src/main/java/io/qdrant/client/QdrantGrpcClient.java
@@ -273,14 +273,14 @@ public class QdrantGrpcClient implements AutoCloseable {
      * @return a new instance of {@link QdrantGrpcClient}
      */
     public QdrantGrpcClient build() {
-      if (checkCompatibility) {
-        String clientVersion = Builder.class.getPackage().getImplementationVersion();
-        checkVersionsCompatibility(clientVersion);
-      }
-
       CallCredentials credentials = this.callCredentials;
       if (credentials == null && (apiKey != null || headers != null)) {
         credentials = new MetadataCredentials(apiKey, headers);
+      }
+
+      if (checkCompatibility) {
+        String clientVersion = Builder.class.getPackage().getImplementationVersion();
+        checkVersionsCompatibility(clientVersion, credentials);
       }
 
       return new QdrantGrpcClient(channel, shutdownChannelOnClose, credentials, timeout);
@@ -301,11 +301,12 @@ public class QdrantGrpcClient implements AutoCloseable {
       return channelBuilder.build();
     }
 
-    private void checkVersionsCompatibility(String clientVersion) {
+    private void checkVersionsCompatibility(
+        String clientVersion, @Nullable CallCredentials credentials) {
       try {
         String serverVersion =
             QdrantGrpc.newBlockingStub(this.channel)
-                .withCallCredentials(this.callCredentials)
+                .withCallCredentials(credentials)
                 .healthCheck(QdrantOuterClass.HealthCheckRequest.getDefaultInstance())
                 .getVersion();
         if (!VersionsCompatibilityChecker.isCompatible(clientVersion, serverVersion)) {

--- a/src/test/java/io/qdrant/client/QdrantGrpcClientCompatibilityTest.java
+++ b/src/test/java/io/qdrant/client/QdrantGrpcClientCompatibilityTest.java
@@ -1,0 +1,61 @@
+package io.qdrant.client;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.grpc.CallCredentials;
+import io.grpc.ManagedChannel;
+import io.qdrant.client.grpc.QdrantGrpc;
+import io.qdrant.client.grpc.QdrantOuterClass;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
+
+/**
+ * Unit tests for the version compatibility check performed by {@link
+ * QdrantGrpcClient.Builder#build()}.
+ *
+ * <p>Regression coverage: the check must authenticate with the credentials configured via {@link
+ * QdrantGrpcClient.Builder#withApiKey(String)}. Previously the check was issued before those
+ * credentials were resolved, so against an auth-required server (e.g. Qdrant Cloud) it failed with
+ * {@code "Failed to obtain server version"}.
+ */
+class QdrantGrpcClientCompatibilityTest {
+
+  @Test
+  void compatibility_check_uses_api_key_credentials_from_with_api_key() {
+    ManagedChannel channel = mock(ManagedChannel.class);
+    QdrantGrpc.QdrantBlockingStub stub = mock(QdrantGrpc.QdrantBlockingStub.class);
+    QdrantOuterClass.HealthCheckReply reply =
+        QdrantOuterClass.HealthCheckReply.newBuilder()
+            .setTitle("qdrant")
+            .setVersion("1.0.0")
+            .build();
+
+    try (MockedStatic<QdrantGrpc> grpc = mockStatic(QdrantGrpc.class)) {
+      grpc.when(() -> QdrantGrpc.newBlockingStub(any())).thenReturn(stub);
+      when(stub.withCallCredentials(any())).thenReturn(stub);
+      when(stub.healthCheck(any())).thenReturn(reply);
+
+      // checkCompatibility = true so build() runs the version check.
+      QdrantGrpcClient client =
+          QdrantGrpcClient.newBuilder(channel, false, true).withApiKey("my-api-key").build();
+      client.close();
+
+      ArgumentCaptor<CallCredentials> credentialsCaptor =
+          ArgumentCaptor.forClass(CallCredentials.class);
+      verify(stub).withCallCredentials(credentialsCaptor.capture());
+
+      CallCredentials usedCredentials = credentialsCaptor.getValue();
+      assertNotNull(
+          usedCredentials,
+          "Version compatibility check must run with the API key credentials, not null");
+      assertInstanceOf(MetadataCredentials.class, usedCredentials);
+    }
+  }
+}

--- a/src/test/java/io/qdrant/client/QdrantGrpcClientCompatibilityTest.java
+++ b/src/test/java/io/qdrant/client/QdrantGrpcClientCompatibilityTest.java
@@ -19,11 +19,6 @@ import org.mockito.MockedStatic;
 /**
  * Unit tests for the version compatibility check performed by {@link
  * QdrantGrpcClient.Builder#build()}.
- *
- * <p>Regression coverage: the check must authenticate with the credentials configured via {@link
- * QdrantGrpcClient.Builder#withApiKey(String)}. Previously the check was issued before those
- * credentials were resolved, so against an auth-required server (e.g. Qdrant Cloud) it failed with
- * {@code "Failed to obtain server version"}.
  */
 class QdrantGrpcClientCompatibilityTest {
 
@@ -42,7 +37,6 @@ class QdrantGrpcClientCompatibilityTest {
       when(stub.withCallCredentials(any())).thenReturn(stub);
       when(stub.healthCheck(any())).thenReturn(reply);
 
-      // checkCompatibility = true so build() runs the version check.
       QdrantGrpcClient client =
           QdrantGrpcClient.newBuilder(channel, false, true).withApiKey("my-api-key").build();
       client.close();


### PR DESCRIPTION
Fixes #131

### Problem

When credentials are set via `withApiKey(...)`, the `checkCompatibility` health check in `build()` runs unauthenticated and logs `"Failed to obtain server version"` against auth-required servers (e.g. Qdrant Cloud). This regressed #96 (fixed in #97) starting in `1.18.0`: the custom-headers refactor (`49e4826`) changed `withApiKey()` to defer building `MetadataCredentials` until **after** the compatibility check, so the check saw a null `callCredentials`.

### Fix

Resolve the effective `CallCredentials` (explicit `callCredentials`, otherwise from `apiKey`/`headers`) **before** the compatibility check, and pass them into `checkVersionsCompatibility(...)`. No public API change.

### Test

Adds `QdrantGrpcClientCompatibilityTest` (uses the already-declared `mockito-core`, no live server required). It mocks the gRPC stub and asserts `build()` invokes the version check with the non-null `MetadataCredentials` derived from `withApiKey(...)`. Verified that the test **fails** against the pre-fix code and **passes** with the fix.
